### PR TITLE
Fetch bank of israel interest rates

### DIFF
--- a/src/app/api/boi/rates/route.ts
+++ b/src/app/api/boi/rates/route.ts
@@ -23,7 +23,8 @@ export async function GET(req: NextRequest) {
 
   try {
     const data = await fetchBoiRates({ from, to });
-    if (redis) {
+    const isFallback = data && typeof data === "object" && data.source === "fallback";
+    if (redis && !isFallback) {
       await redis.set(cacheKey, JSON.stringify(data), "EX", ttlSeconds);
     }
     return NextResponse.json(data, { status: 200 });

--- a/src/lib/boi.ts
+++ b/src/lib/boi.ts
@@ -1,18 +1,44 @@
 export type RatesQuery = { from?: string; to?: string };
 
+function buildFallbackRates(asOfDate?: string) {
+  const asOf = asOfDate || new Date().toISOString().slice(0, 10);
+  // Conservative placeholders to avoid over-promising if real API is unavailable
+  // The UI will map relevant keys per track id
+  return {
+    prime: 6.0,
+    fixed_unlinked: 3.8,
+    fixed_cpi: 4.2,
+    gov_bonds: 3.5,
+    gov_bonds_cpi: 3.7,
+    asOf,
+    source: "fallback",
+  } as const;
+}
+
 export async function fetchBoiRates({ from, to }: RatesQuery): Promise<any> {
   const base = process.env.BOI_RATES_URL;
-  if (!base) throw new Error("BOI_RATES_URL is not set");
-  const url = new URL(base);
-  if (from) url.searchParams.set("from", from);
-  if (to) url.searchParams.set("to", to);
+  const asOf = to || from || new Date().toISOString().slice(0, 10);
 
-  const res = await fetch(url.toString(), {
-    headers: { Accept: "application/json" },
-    cache: "no-store",
-  });
-  if (!res.ok) {
-    throw new Error(`BOI API error: ${res.status} ${res.statusText}`);
+  if (!base) {
+    return buildFallbackRates(asOf);
   }
-  return await res.json();
+
+  try {
+    const url = new URL(base);
+    if (from) url.searchParams.set("from", from);
+    if (to) url.searchParams.set("to", to);
+
+    const res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      // fall back instead of throwing to avoid 502 to clients
+      return buildFallbackRates(asOf);
+    }
+    return await res.json();
+  } catch {
+    // Network/parse error – return safe fallback
+    return buildFallbackRates(asOf);
+  }
 }


### PR DESCRIPTION
Implement server-side fallback for BOI rates API to prevent 502 errors.

The `/api/boi/rates` endpoint previously returned a 502 if the `BOI_RATES_URL` environment variable was missing or the external Bank of Israel API call failed. This change ensures a default set of rates is returned, allowing the interactive calculator to function without breaking, even if the external data source is unavailable. Additionally, fallback data is not cached to avoid polluting the Redis cache with temporary values.

---
<a href="https://cursor.com/background-agent?bcId=bc-0badc70b-b4f2-4d2d-a8cb-68b214d338f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0badc70b-b4f2-4d2d-a8cb-68b214d338f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

