### PR TITLE
Fix auth options url property

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,6 @@ export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
   secret: process.env.NEXTAUTH_SECRET,
-  url: process.env.NEXTAUTH_URL,
   debug: process.env.NODE_ENV === "development",
   providers: [
     Credentials({


### PR DESCRIPTION
Remove `url` property from `authOptions` to fix a TypeScript compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-619f9938-9b9f-44a7-8636-d621a5e3cfb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-619f9938-9b9f-44a7-8636-d621a5e3cfb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

