### PR TITLE
Fix layoutshell import error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "mashkalanta-wizard"
   ]
 }


### PR DESCRIPTION
Exclude the `mashkalanta-wizard` directory from the main project's TypeScript compilation to resolve import errors.

The `mashkalanta-wizard` directory contains a separate Next.js application with its own `tsconfig.json` and component structure. The main project's `tsconfig.json` was inadvertently attempting to compile these files, leading to module resolution conflicts. Excluding this directory ensures that each application is compiled independently.

---
<a href="https://cursor.com/background-agent?bcId=bc-e82533f8-e58a-4ad7-8533-d7b48ee095f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e82533f8-e58a-4ad7-8533-d7b48ee095f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

