### PR TITLE
Fix type error in comparison panel

### DIFF
--- a/src/components/mortgage-advisor/ComparisonPanel.tsx
+++ b/src/components/mortgage-advisor/ComparisonPanel.tsx
@@ -540,7 +540,7 @@ export function ComparisonPanel({ mixes, selectedIds, onClearSelection }: Compar
                     <Tooltip 
                       formatter={(value, name) => [
                         formatCurrency(value as number),
-                        calculations[parseInt(name.replace('mix', ''))]?.mix.name || ''
+                        calculations[parseInt(typeof name === 'string' ? name.replace('mix', '') : String(name).replace('mix', ''))]?.mix.name || ''
                       ]}
                       labelStyle={{ direction: 'rtl' }}
                     />


### PR DESCRIPTION
Add a type guard to the `formatter` function's `name` parameter to resolve a TypeScript error when `name` is a number.

The `name` parameter in the `Tooltip`'s `formatter` function was typed as `NameType`, which could be a string or a number. The code was attempting to call `.replace('mix', '')` directly on `name`, leading to a TypeScript error when `name` was a number. The fix explicitly checks if `name` is a string; if not, it converts it to a string before calling `replace`, ensuring type safety and preventing runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3b05928-c4c5-44fa-8b31-4fa003c5e3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3b05928-c4c5-44fa-8b31-4fa003c5e3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

