### PR TITLE
Fix type error in mortgage comparison panel

### DIFF
--- a/src/components/mortgage-advisor/ComparisonPanel.tsx
+++ b/src/components/mortgage-advisor/ComparisonPanel.tsx
@@ -540,7 +540,7 @@ export function ComparisonPanel({ mixes, selectedIds, onClearSelection }: Compar
                     <Tooltip 
                       formatter={(value, name) => [
                         formatCurrency(value as number),
-                        calculations[parseInt(name.replace('mix', ''))]?.mix.name || ''
+                        calculations[parseInt((name as string).replace('mix', ''))]?.mix.name || ''
                       ]}
                       labelStyle={{ direction: 'rtl' }}
                     />


### PR DESCRIPTION
Add type assertion for `name` in Tooltip formatter to fix build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf79ba7e-7500-497c-b88a-513f89735c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf79ba7e-7500-497c-b88a-513f89735c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

