### PR TITLE
Fix type error in comparison panel

### DIFF
--- a/src/components/mortgage-advisor/ComparisonPanel.tsx
+++ b/src/components/mortgage-advisor/ComparisonPanel.tsx
@@ -540,7 +540,7 @@ export function ComparisonPanel({ mixes, selectedIds, onClearSelection }: Compar
                     <Tooltip 
                       formatter={(value, name) => [
                         formatCurrency(value as number),
-                        calculations[parseInt(name.replace('mix', ''))]?.mix.name || ''
+                        calculations[parseInt(typeof name === 'string' ? name.replace('mix', '') : String(name).replace('mix', ''))]?.mix.name || ''
                       ]}
                       labelStyle={{ direction: 'rtl' }}
                     />


### PR DESCRIPTION
Fixes a TypeScript error in `ComparisonPanel.tsx` where `name.replace()` was called on a `NameType` that could be a number.

The `formatter` function's `name` parameter from Recharts can be a string or a number. The original code directly called `.replace()` on `name`, which failed when `name` was a number. The fix adds a type check to ensure `name` is a string before calling `replace`, or converts it to a string if it's a number, preventing the type error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff27d531-11a3-4fa0-937e-8f22d0d7db3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff27d531-11a3-4fa0-937e-8f22d0d7db3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

