### PR TITLE
Fix mortgage offer upload and manual entry

### DIFF
--- a/src/app/mortgage-planning/page.tsx
+++ b/src/app/mortgage-planning/page.tsx
@@ -1540,6 +1540,7 @@ export default function MortgagePlanning() {
         {currentStep === 'personal-info' && renderPersonalInfoForm()}
         {currentStep === 'existing-property' && renderExistingPropertyForm()}
         {currentStep === 'reverse-mortgage' && renderReverseMortgageForm()}
+        {currentStep === 'offer-analysis' && renderOfferAnalysisStep()}
         {currentStep === 'results' && renderResults()}
       </div>
 


### PR DESCRIPTION
Render the `offer-analysis` step to display the existing offer analysis tools, resolving the blank page issue when accessing this functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-461e4fc5-29fe-4d5d-b73f-5ce955914b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-461e4fc5-29fe-4d5d-b73f-5ce955914b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

