### PR TITLE
feat: Display mortgage terms table directly after image upload

### DIFF
--- a/src/app/mortgage-planning/page.tsx
+++ b/src/app/mortgage-planning/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import NavBar from '@/components/ui/navbar';
 import EquityCalculator from '@/components/ui/equitycalc';
+import MortgageTermsTable from '@/components/mortgage-application/MortgageTermsTable';
 
 interface UserData {
   propertyType: string;
@@ -47,6 +48,9 @@ export default function MortgagePlanning() {
   });
   const [showEquityCalculator, setShowEquityCalculator] = useState(false);
   const [showCapitalWarning, setShowCapitalWarning] = useState(false);
+  const [analyzedTerms, setAnalyzedTerms] = useState<any>(null);
+  const [extractedText, setExtractedText] = useState<string>('');
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
 
   // Load data from localStorage on component mount
   useEffect(() => {
@@ -59,6 +63,23 @@ export default function MortgagePlanning() {
       } catch (error) {
         console.error('Error loading saved data:', error);
       }
+    }
+  }, []);
+
+  // Load analyzed terms if available
+  useEffect(() => {
+    try {
+      const termsData = localStorage.getItem('analyzedMortgageTerms');
+      const textData = localStorage.getItem('extractedText');
+
+      if (termsData) {
+        setAnalyzedTerms(JSON.parse(termsData));
+      }
+      if (textData) {
+        setExtractedText(textData);
+      }
+    } catch (error) {
+      console.error('Error loading analyzed data:', error);
     }
   }, []);
 
@@ -461,17 +482,40 @@ export default function MortgagePlanning() {
                     type="file"
                     accept="image/*,application/pdf"
                     className="hidden"
-                    onChange={(e) => {
+                    onChange={async (e) => {
                       const file = e.target.files && e.target.files[0];
                       if (file) {
+                        setIsAnalyzing(true);
                         const reader = new FileReader();
-                        reader.onload = () => {
+                        reader.onload = async () => {
                           try {
-                            localStorage.setItem('uploadedBankOffer', String(reader.result));
-                            alert('הקובץ נטען. ננתח את ההצעה במסך כלי היועצים.');
-                            window.location.href = '/mortgage-advisor';
+                            const imageData = String(reader.result);
+                            localStorage.setItem('uploadedBankOffer', imageData);
+
+                            // Send to API for analysis
+                            const response = await fetch('/api/analyze-image', {
+                              method: 'POST',
+                              headers: {
+                                'Content-Type': 'application/json',
+                              },
+                              body: JSON.stringify({ imageData }),
+                            });
+
+                            if (response.ok) {
+                              const result = await response.json();
+                              setAnalyzedTerms(result.mortgageTerms);
+                              setExtractedText(result.extractedText);
+                              localStorage.setItem('analyzedMortgageTerms', JSON.stringify(result.mortgageTerms));
+                              localStorage.setItem('extractedText', result.extractedText);
+                            } else {
+                              console.error('Error analyzing image:', await response.text());
+                              alert('שגיאה בניתוח התמונה. נסה שוב.');
+                            }
                           } catch (err) {
-                            console.error('שגיאה בשמירת הקובץ:', err);
+                            console.error('שגיאה בעיבוד התמונה:', err);
+                            alert('שגיאה בעיבוד התמונה. נסה שוב.');
+                          } finally {
+                            setIsAnalyzing(false);
                           }
                         };
                         reader.readAsDataURL(file);
@@ -508,6 +552,22 @@ export default function MortgagePlanning() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Display analyzed mortgage terms if available */}
+      {isAnalyzing && (
+        <div className="mt-8 text-center">
+          <div className="inline-flex items-center px-4 py-2 bg-blue-100 text-blue-800 rounded-lg">
+            <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+            מנתח את התמונה...
+          </div>
+        </div>
+      )}
+
+      {analyzedTerms && (
+        <div className="mt-8">
+          <MortgageTermsTable terms={analyzedTerms} extractedText={extractedText} />
+        </div>
+      )}
 
       <div className="text-center mt-10">
         <Button

--- a/src/components/mortgage-application/MortgageTermsTable.tsx
+++ b/src/components/mortgage-application/MortgageTermsTable.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Download, FileText } from 'lucide-react';
+
+interface MortgageTerms {
+  bankName?: string;
+  loanAmount?: string;
+  interestRate?: string;
+  loanPeriod?: string;
+  monthlyPayment?: string;
+  ltv?: string;
+  fees?: string;
+  additionalTerms: string[];
+}
+
+interface MortgageTermsTableProps {
+  terms: MortgageTerms;
+  extractedText: string;
+}
+
+const MortgageTermsTable: React.FC<MortgageTermsTableProps> = ({ terms, extractedText }) => {
+  const handleDownloadJson = () => {
+    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(terms, null, 2));
+    const downloadAnchorNode = document.createElement('a');
+    downloadAnchorNode.setAttribute("href", dataStr);
+    downloadAnchorNode.setAttribute("download", "mortgage_terms.json");
+    document.body.appendChild(downloadAnchorNode);
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  };
+
+  const termLabels: { [key: string]: string } = {
+    bankName: 'שם הבנק',
+    loanAmount: 'סכום משכנתא',
+    interestRate: 'ריבית',
+    loanPeriod: 'תקופה (שנים)',
+    monthlyPayment: 'החזר חודשי',
+    ltv: 'אחוז מימון (LTV)',
+    fees: 'עמלות',
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6 mb-8 border border-gray-200">
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">תנאי משכנתא שזוהו מהצעה</h2>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={handleDownloadJson} className="flex items-center gap-2">
+            <Download className="w-4 h-4" />
+            הורד JSON
+          </Button>
+          {extractedText && (
+            <Button variant="outline" onClick={() => alert(extractedText)} className="flex items-center gap-2">
+              <FileText className="w-4 h-4" />
+              הצג טקסט מלא
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Table className="min-w-full">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[150px] text-right">פרט</TableHead>
+            <TableHead className="text-right">ערך</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Object.entries(termLabels).map(([key, label]) => (
+            terms[key as keyof MortgageTerms] && (
+              <TableRow key={key}>
+                <TableCell className="font-medium text-right">{label}</TableCell>
+                <TableCell className="text-right">
+                  <Badge variant="secondary" className="text-base py-1 px-3">
+                    {terms[key as keyof MortgageTerms]}
+                    {key === 'loanAmount' || key === 'monthlyPayment' || key === 'fees' ? ' ₪' : ''}
+                    {key === 'interestRate' || key === 'ltv' ? ' %' : ''}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            )
+          ))}
+          {terms.additionalTerms.length > 0 && (
+            <TableRow>
+              <TableCell className="font-medium text-right">תנאים נוספים</TableCell>
+              <TableCell className="text-right">
+                <div className="flex flex-wrap gap-2 justify-end">
+                  {terms.additionalTerms.map((term, index) => (
+                    <Badge key={index} variant="outline" className="text-sm py-1 px-2">
+                      {term}
+                    </Badge>
+                  ))}
+                </div>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default MortgageTermsTable;

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-right align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
- Add MortgageTermsTable component to show analyzed mortgage terms
- Integrate Google Vision API analysis directly in mortgage planning page
- Show loading indicator during image analysis
- Display extracted terms (bank name, loan amount, interest rate, period, etc.)
- Add table UI components for structured data display
- Keep analyzed data in localStorage for persistence