### PR TITLE
Fix type error in build

### DIFF
--- a/src/app/financial-dynamics/page.tsx
+++ b/src/app/financial-dynamics/page.tsx
@@ -185,6 +185,10 @@ export default function FinancialDynamicsPage() {
     }).format(value);
   };
 
+  const formatPercent = (value: number) => {
+    return `${value.toFixed(1)}%`;
+  };
+
   // Interactive functions
   const handleElementHover = (elementType: string, data: any) => {
     setHoveredElement(elementType);
@@ -687,13 +691,13 @@ export default function FinancialDynamicsPage() {
                           isActive={(inputs.allocToDebt > 0 && currentState?.liquid > 0)} 
                           direction="vertical"
                           className="w-full h-full rounded-full"
-                          color="red"
+                          color="orange"
                         />
                         <WaterFlowAnimation 
                           isActive={(inputs.allocToDebt > 0 && currentState?.liquid > 0)} 
                           direction="vertical"
                           className="left-1/2 transform -translate-x-1/2"
-                          color="red"
+                          color="orange"
                         />
                       </div>
                       


### PR DESCRIPTION
Add missing `formatPercent` utility and update invalid color prop values to resolve TypeScript compilation errors.

The build failed because `formatPercent` was used but not defined, and the `color` prop for `ContinuousFlowEffect` and `WaterFlowAnimation` components did not accept 'red', which was being used.

---
<a href="https://cursor.com/background-agent?bcId=bc-2894cc36-279f-43b7-a972-608a593d1f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2894cc36-279f-43b7-a972-608a593d1f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

